### PR TITLE
fix memory allocated in json_tokener_parse not freed

### DIFF
--- a/ipdb.c
+++ b/ipdb.c
@@ -54,6 +54,7 @@ ipdb_meta_data *parse_meta_data(const char *meta_json) {
         json_object_iter_next(&language);
     }
     json_object_iter_end(value);
+    json_object_put(obj);
     return meta_data;
 }
 

--- a/main.c
+++ b/main.c
@@ -4,9 +4,20 @@
 #include <sys/time.h>
 #include "ipdb.h"
 
-int main() {
+int main(const int argc, const char ** argv) {
+
+	char * defaultDB = "/root/cpp/ipdb-c/mydata6vipday4.ipdb";
+	char * db;
+
+	if (argc == 1) {
+		db = defaultDB;
+	}
+	else {
+		db = (char *) argv[1];
+	}
+
     ipdb_reader *reader;
-    int err = ipdb_reader_new("/root/cpp/ipdb-c/mydata6vipday4.ipdb", &reader);
+    int err = ipdb_reader_new(db, &reader);
     printf("new ipdb reader err: %d\n", err);
     if (!err) {
         printf("ipdb build time: %li\n", reader->meta->build_time);


### PR DESCRIPTION
Fix memory leaking issue. `json_object *obj` shoule be `json_object_put`-ed afterwards.

```
==29404== 
==29404== HEAP SUMMARY:
==29404==     in use at exit: 2,795 bytes in 24 blocks
==29404==   total heap usage: 50 allocs, 26 frees, 3,660,411 bytes allocated
==29404== 
==29404== 2,795 (96 direct, 2,699 indirect) bytes in 1 blocks are definitely lost in loss record 10 of 10
==29404==    at 0x483956F: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==29404==    by 0x4896BED: ??? (in /usr/lib64/libjson-c.so.4.0.0)
==29404==    by 0x48970F5: json_object_new_object (in /usr/lib64/libjson-c.so.4.0.0)
==29404==    by 0x48990F5: json_tokener_parse_ex (in /usr/lib64/libjson-c.so.4.0.0)
==29404==    by 0x489A5C6: json_tokener_parse_verbose (in /usr/lib64/libjson-c.so.4.0.0)
==29404==    by 0x489A618: json_tokener_parse (in /usr/lib64/libjson-c.so.4.0.0)
==29404==    by 0x109898: parse_meta_data (ipdb.c:27)
==29404==    by 0x109CDC: ipdb_reader_new (ipdb.c:85)
==29404==    by 0x10938D: main (main.c:20)
==29404== 
==29404== LEAK SUMMARY:
==29404==    definitely lost: 96 bytes in 1 blocks
==29404==    indirectly lost: 2,699 bytes in 23 blocks
==29404==      possibly lost: 0 bytes in 0 blocks
==29404==    still reachable: 0 bytes in 0 blocks
==29404==         suppressed: 0 bytes in 0 blocks
==29404== 
==29404== For counts of detected and suppressed errors, rerun with: -v
==29404== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

P.S. Wouldn't it be `#include <json-c/json.h>` in `ipdb.c` on most systems ? Tested on Ubuntu 16.04/18.04 and Gentoo.