### PR TITLE
bugfix: data size calculation and data range check

### DIFF
--- a/ipdb.c
+++ b/ipdb.c
@@ -144,7 +144,7 @@ int ipdb_resolve(ipdb_reader *reader, int node, const char **bytes) {
         return ErrDatabaseError;
     }
 
-    int size = (reader->data[resolved] << 8) | reader->data[resolved + 2];
+    int size = (reader->data[resolved] << 8) | reader->data[resolved + 1];
     if ((resolved + 2 + size) > reader->data_size) {
         return ErrDatabaseError;
     }
@@ -162,7 +162,7 @@ int ipdb_search(ipdb_reader *reader, const u_char *ip, int bit_count, int *node)
     }
 
     for (int i = 0; i < bit_count; ++i) {
-        if (*node > reader->meta->node_count) {
+        if (*node >= reader->meta->node_count) {
             break;
         }
 
@@ -170,7 +170,7 @@ int ipdb_search(ipdb_reader *reader, const u_char *ip, int bit_count, int *node)
                                ((0xFF & ((int) ip[i >> 3])) >> (unsigned int) (7 - (i % 8))) & 1);
     }
 
-    if (*node > reader->meta->node_count) {
+    if (*node >= reader->meta->node_count) {
         return ErrNoErr;
     }
     return ErrDataNotExists;


### PR DESCRIPTION
1. Data size use two bytes to store size, so it should used data[offset] << 8 | data[offset + 1] to calculate size
2. In some user generated ipdb database, data offset 0 has data too